### PR TITLE
Remove unnecessary comment and set releaseDraft to false in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
     branches: [ 'main' ]
   workflow_dispatch:
 
-# Définition des permissions nécessaires pour créer des releases
 permissions:
   contents: write
   packages: read
@@ -62,5 +61,5 @@ jobs:
           tagName: ${{ github.ref_type == 'tag' && github.ref_name || 'v__VERSION__' }}
           releaseName: "RezLauncher ${{ github.ref_type == 'tag' && github.ref_name || 'v__VERSION__' }}"
           releaseBody: 'See the assets to download this version and install.'
-          releaseDraft: true
+          releaseDraft: false
           prerelease: false


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/build.yml` file to modify release-related configurations. The changes primarily adjust permissions and release behavior.

Workflow configuration updates:

* Removed a commented-out line describing the permissions required for creating releases. This does not affect functionality but cleans up the file. (`[.github/workflows/build.ymlL12](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L12)`)
* Changed the `releaseDraft` property from `true` to `false` in the `jobs` section, ensuring that releases are published immediately instead of being created as drafts. (`[.github/workflows/build.ymlL65-R64](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L65-R64)`)